### PR TITLE
Create and run job definition export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ local_data/
 .ipynb_checkpoints/
 __pycache__/
 notebooks/derby.log
+
+# artifact of dbutils.fs.cp()
+*.crc

--- a/databricks/job_definitions/daily_pipeline/daily_pipeline_create.json
+++ b/databricks/job_definitions/daily_pipeline/daily_pipeline_create.json
@@ -44,8 +44,5 @@
   ],
   "queue": {
     "enabled": true
-  },
-  "run_as": {
-    "user_name": "mboyle35@gatech.edu"
   }
 }

--- a/databricks/job_definitions/daily_pipeline/daily_pipeline_get.json
+++ b/databricks/job_definitions/daily_pipeline/daily_pipeline_get.json
@@ -1,8 +1,5 @@
 {
   "job_id": 99497279881584,
-  "creator_user_name": "mboyle35@gatech.edu",
-  "run_as_user_name": "mboyle35@gatech.edu",
-  "run_as_owner": true,
   "settings": {
     "name": "daily_pipeline",
     "email_notifications": {

--- a/databricks/job_definitions/daily_pipeline/daily_pipeline_reset.json
+++ b/databricks/job_definitions/daily_pipeline/daily_pipeline_reset.json
@@ -46,9 +46,6 @@
     ],
     "queue": {
       "enabled": true
-    },
-    "run_as": {
-      "user_name": "mboyle35@gatech.edu"
     }
   }
 }

--- a/notebooks/export_job_definitions_to_repo.ipynb
+++ b/notebooks/export_job_definitions_to_repo.ipynb
@@ -1,0 +1,439 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "00b3f6c6-0589-4c90-ba72-ddc3cbc2559d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# export_job_definitions_to_repo\n",
+    "\n",
+    "This notebook exports the JSON definitions of a Databricks job into your Git-backed workspace repo under `databricks/job_definitions/{job_name}/`. It saves three JSON variants (`get`, `create`, and `reset`) for better change tracking and automation.\n",
+    "\n",
+    "This notebook is meant to be run only in the Databricks cloud environment, not on your local computer.\n",
+    "\n",
+    "## How to Run This Notebook\n",
+    "- Choose or enter the values for `DRY_RUN` and `job_id` in the widgets above.\n",
+    "- If no widgets are visible, run the first cell below this one. The widgets should now be visible.\n",
+    "- Choose `DRY_RUN = true` to test the functionality without actually saving files to the repo.\n",
+    "- Choose `DRY_RUN = false` to save files for real.\n",
+    "- Click `Run all`\n",
+    "\n",
+    "## When to Run This Notebook\n",
+    "\n",
+    "- To **back up or version control** your job configurations alongside your code.\n",
+    "- After making **intentional job changes** that you want to persist and commit.\n",
+    "\n",
+    "## When NOT to Run This Notebook\n",
+    "\n",
+    "- During temporary or experimental job changes you do **not want to commit**.\n",
+    "- Without a valid job ID or when unsure of the job’s purpose.\n",
+    "\n",
+    "## How to Find the Job ID\n",
+    "\n",
+    "1. In Databricks UI, navigate to **Jobs**.\n",
+    "1. Click on the job you want to export.\n",
+    "1. In the side panel, the job id is the first item under `Job Details`. (The job id is also in the URL: `https://{your workspace id}.azuredatabricks.net/jobs/{job_id}`.)\n",
+    "1. Enter the job ID in the `job_id` parameter widget above.\n",
+    "\n",
+    "## Using the `DRY_RUN` Flag\n",
+    "\n",
+    "- **Set `DRY_RUN` to `true` (default recommended for debugging):**  \n",
+    "  - The notebook fetches the job definition and prints what it *would* do.  \n",
+    "  - No files are written to the repo, and temp files are **not deleted** (allowing inspection).\n",
+    "- **Set `DRY_RUN` to `false` to perform actual export:**  \n",
+    "  - The notebook writes JSON files into the Git-backed repo folder.  \n",
+    "  - Temporary files are cleaned up after a successful run.\n",
+    "\n",
+    "Always review outputs before setting `DRY_RUN=false` to avoid unintended overwrites. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "0ea862f8-2cae-4cbd-b105-94b3f94cf8ba",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize widgets\n",
+    "\n",
+    "def widget_exists(name):\n",
+    "    try:\n",
+    "        dbutils.widgets.get(name)\n",
+    "        return True\n",
+    "    except Exception:\n",
+    "        return False\n",
+    "\n",
+    "if not widget_exists(\"job_id\"):\n",
+    "    dbutils.widgets.text(\"job_id\", \"\")\n",
+    "\n",
+    "if not widget_exists(\"DRY_RUN\"):\n",
+    "    dbutils.widgets.dropdown(\"DRY_RUN\", \"true\", [\"true\", \"false\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "885a83bf-3895-47c4-83d5-65ba44e160ff",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Get parameters from widgets\n",
+    "\n",
+    "job_id_str = dbutils.widgets.get(\"job_id\")\n",
+    "DRY_RUN = dbutils.widgets.get(\"DRY_RUN\").lower() == \"true\"\n",
+    "\n",
+    "if not job_id_str.isdigit():\n",
+    "    raise ValueError(\"Invalid job_id provided.\")\n",
+    "    \n",
+    "JOB_ID = int(job_id_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4087c0ea-0220-4206-823c-127083cd978b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Imports and config\n",
+    "import os\n",
+    "import json\n",
+    "import shutil\n",
+    "import requests\n",
+    "import copy\n",
+    "\n",
+    "\n",
+    "# Securely read from secret scope\n",
+    "DATABRICKS_TOKEN = dbutils.secrets.get(scope=\"spelling-bee-scope\", key=\"databricks-token\")\n",
+    "\n",
+    "DATABRICKS_HOST = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().get()\n",
+    "print(f\"Detected Databricks Host: {DATABRICKS_HOST}\")\n",
+    "\n",
+    "# Git-backed repo path\n",
+    "user_name = dbutils.notebook.entry_point.getDbutils().notebook().getContext().tags().get(\"user\").get()\n",
+    "user_home = f\"/Workspace/Users/{user_name}\"\n",
+    "print(f\"User home path: {user_home}\")\n",
+    "\n",
+    "REPO_BASE_PATH = f\"{user_home}/spelling-bee-solver-training\"\n",
+    "print(f\"Repo base path: {REPO_BASE_PATH}\")\n",
+    "\n",
+    "JOB_DEF_PATH = f\"{REPO_BASE_PATH}/databricks/job_definitions\"\n",
+    "\n",
+    "# Local temp directory\n",
+    "LOCAL_TMP_DIR = \"/tmp/job_exports\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "9c505162-e6f0-4027-b65b-00f852fe4e75",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Utility functions\n",
+    "\n",
+    "METADATA_FIELDS = [\"creator_user_name\", \"run_as_user_name\", \"run_as_owner\"]\n",
+    "\n",
+    "def strip_metadata_fields(job_json):\n",
+    "    for field in METADATA_FIELDS:\n",
+    "        job_json.pop(field, None)\n",
+    "\n",
+    "    return job_json\n",
+    "\n",
+    "def get_job_definition(job_id):\n",
+    "    url = f\"{DATABRICKS_HOST}/api/2.1/jobs/get?job_id={job_id}\"\n",
+    "    headers = {\"Authorization\": f\"Bearer {DATABRICKS_TOKEN}\"}\n",
+    "    response = requests.get(url, headers=headers)\n",
+    "    response.raise_for_status()\n",
+    "    return strip_metadata_fields(response.json())\n",
+    "\n",
+    "def convert_for_create(job_json):\n",
+    "    # Make a deep copy of the settings\n",
+    "    create_json = copy.deepcopy(job_json[\"settings\"])\n",
+    "    create_json.pop(\"format\", None)\n",
+    "    create_json.pop(\"run_as\", None)  # remove user-specific execution context\n",
+    "    return create_json\n",
+    "\n",
+    "def convert_for_reset(job_json):\n",
+    "    return {\n",
+    "        \"job_id\": job_json[\"job_id\"],\n",
+    "        \"new_settings\": convert_for_create(job_json)\n",
+    "    }\n",
+    "\n",
+    "def save_json_locally(obj, path):\n",
+    "    os.makedirs(os.path.dirname(path), exist_ok=True)\n",
+    "    with open(path, \"w\") as f:\n",
+    "        json.dump(obj, f, indent=2)\n",
+    "\n",
+    "def copy_to_repo(local_path, repo_path):\n",
+    "    if DRY_RUN:\n",
+    "        print(f\"DRY RUN: Would have copied {local_path} to {repo_path}\")\n",
+    "        return\n",
+    "    \n",
+    "    # in order to overwrite, first attempt to remove file\n",
+    "    try:\n",
+    "        dbutils.fs.rm(f\"file:{repo_path}\")\n",
+    "    except Exception:\n",
+    "        pass  # file might not exist, which is fine\n",
+    "\n",
+    "    # copy file\n",
+    "    dbutils.fs.cp(f\"file:{local_path}\", f\"file:{repo_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "871cb222-be67-494c-8a99-a3ba626ad9b1",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Main logic\n",
+    "\n",
+    "success = False\n",
+    "\n",
+    "try:\n",
+    "    job_json = get_job_definition(JOB_ID)\n",
+    "    job_name = job_json[\"settings\"][\"name\"]\n",
+    "\n",
+    "    # File paths\n",
+    "    job_dir = os.path.join(JOB_DEF_PATH, job_name)\n",
+    "    os.makedirs(job_dir, exist_ok=True)\n",
+    "\n",
+    "    local_get = os.path.join(LOCAL_TMP_DIR, f\"{job_name}_get.json\")\n",
+    "    local_create = os.path.join(LOCAL_TMP_DIR, f\"{job_name}_create.json\")\n",
+    "    local_reset = os.path.join(LOCAL_TMP_DIR, f\"{job_name}_reset.json\")\n",
+    "\n",
+    "    repo_get = os.path.join(job_dir, f\"{job_name}_get.json\")\n",
+    "    repo_create = os.path.join(job_dir, f\"{job_name}_create.json\")\n",
+    "    repo_reset = os.path.join(job_dir, f\"{job_name}_reset.json\")\n",
+    "\n",
+    "    # Save all variants\n",
+    "    save_json_locally(job_json, local_get)\n",
+    "    save_json_locally(convert_for_create(job_json), local_create)\n",
+    "    save_json_locally(convert_for_reset(job_json), local_reset)\n",
+    "\n",
+    "    # Copy to workspace repo\n",
+    "    copy_to_repo(local_get, repo_get)\n",
+    "    copy_to_repo(local_create, repo_create)\n",
+    "    copy_to_repo(local_reset, repo_reset)\n",
+    "\n",
+    "    if not DRY_RUN:\n",
+    "        print(f\"✅ Exported job '{job_name}' to workspace repo at {job_dir}\")\n",
+    "    success = True\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"❌ Error exporting job: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "bb9fd4df-60ab-427b-9706-aca1e3223a53",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if success:\n",
+    "    if DRY_RUN:\n",
+    "        print(\"🧪 DRY_RUN enabled — skipping temp file cleanup.\")\n",
+    "    else:\n",
+    "        shutil.rmtree(LOCAL_TMP_DIR, ignore_errors=True)\n",
+    "        print(\"✅ Cleaned up temporary files.\")\n",
+    "else:\n",
+    "    print(f\"⚠️ Temp files left in {LOCAL_TMP_DIR} for inspection.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "c71d16d9-c24e-4a26-8916-8dd501347db9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if DRY_RUN or not success:\n",
+    "    print(\"⚠️ Here are the temp files that would have been created:\")\n",
+    "    for file_path in [local_get, local_create, local_reset]:\n",
+    "        print(f\"File path: {file_path}\")\n",
+    "        with open(file_path, 'r') as f:\n",
+    "            print(f.read())\n",
+    "        print(f\"=====end of file======\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": -1,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "export_job_definitions_to_repo",
+   "widgets": {
+    "DRY_RUN": {
+     "currentValue": "false",
+     "nuid": "97d0e40a-337a-457f-875a-74c54c87d0eb",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "true",
+      "label": null,
+      "name": "DRY_RUN",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "true",
+        "false"
+       ],
+       "fixedDomain": true,
+       "multiselect": false
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "dropdown",
+      "defaultValue": "true",
+      "label": null,
+      "name": "DRY_RUN",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": null,
+       "choices": [
+        "true",
+        "false"
+       ]
+      }
+     }
+    },
+    "job_id": {
+     "currentValue": "99497279881584",
+     "nuid": "f4f9427f-7de0-4114-b89e-ba409dd60261",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": null,
+      "name": "job_id",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": null,
+      "name": "job_id",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": null,
+       "validationRegex": null
+      }
+     }
+    }
+   }
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Create manual notebook to export job definitions from databricks to source control.

Creates get, create, and reset configs. Strips user/owner metadata from configs to avoid git churn.