### PR TITLE
bootstrap word_states notebook

### DIFF
--- a/notebooks/bootstrap_words_04_word_states.ipynb
+++ b/notebooks/bootstrap_words_04_word_states.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d6f22e25-df7c-4aed-9e83-55f9fca341db",
+   "metadata": {},
+   "source": [
+    "# bootstrap_words_03_word_states\n",
+    "\n",
+    "Creates `silver.word_states` table with columns:\n",
+    "- `word`\n",
+    "- `letter_set`\n",
+    "- `frequency`\n",
+    "- `embedding`\n",
+    "- `last_seen_on` (date type, nullable)\n",
+    "- `label` (`0.0` or `1.0`, nullable)\n",
+    "- `batch_id` (string, `\"bootstrap_{stage}_{num}\"` or `str(puzzle_date)`\n",
+    "\n",
+    "Steps in the process:\n",
+    "- reduce the batch reader size to avoid vectorized reader using too much memory\n",
+    "- TODO: Find out if this step should only happen locally or on Databricks too\n",
+    "    - if local only, put this config change in `if not is_databricks_env():` block\n",
+    "- read in `bronze.words` Delta table\n",
+    "- rename `date_added` -> `last_seen_on` (should all be null for bootstrap)\n",
+    "- label column = null (float type)\n",
+    "- batch_id col = `\"bootstrap_words_01\"`\n",
+    "- drop version column\n",
+    "- save as Delta table `silver.word_states`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "381700de-7abd-43c7-ba8c-fc9dab1e1616",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run './00_setup.ipynb'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0837589-9af4-447a-859b-83634f2662a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyspark.sql.functions as F\n",
+    "from pyspark.sql.types import *\n",
+    "\n",
+    "from src.envutils import is_databricks_env\n",
+    "from src.sparkdbutils import create_db, create_repartitioned_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "875aacf4-57ed-45ad-85ee-9960eaac7b18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Config for this notebook, possibly local only\n",
+    "if not is_databricks_env():\n",
+    "    print(\"updating spark config for this notebook\")\n",
+    "    spark.conf.set(\"spark.sql.parquet.columnarReaderBatchSize\", \"1024\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ae36b67-1f06-4a32-af4a-326307e2556e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Should be pipeline parameters\n",
+    "_SOURCE_DB_NAME = \"bronze\"\n",
+    "_SOURCE_TABLE_NAME = \"words\"\n",
+    "_TARGET_DB_NAME = \"silver\"\n",
+    "_TARGET_TABLE_NAME = \"word_states\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06521aee-529c-46d7-8ada-592ccaae913b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in bronze.words table\n",
+    "df = spark.sql(f\"SELECT * FROM {_SOURCE_DB_NAME}.{_SOURCE_TABLE_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a98d1cf-7dd1-4db1-8d34-3c18c6295b3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rename date_added -> last_seen_on\n",
+    "df = df.withColumnRenamed(\"date_added\", \"last_seen_on\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c892787-0302-40ee-bb6b-504a1b52aa96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add label column (1.0, or 0.0, all null for now)\n",
+    "df = df.withColumn(\"label\", F.lit(None).cast(\"float\")) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a881e3c3-eb4c-4653-844f-ff42cc066c69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add batch id (\"bootstrap_words_1\" for this batch)\n",
+    "df = df.withColumn(\"batch_id\", F.lit(\"bootstrap_words_1\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d54870f-6722-42fb-aaaa-b19a11430e61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop version column\n",
+    "df = df.drop(\"version\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "059a6897-e13b-4754-88a3-e3b38d71516b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to target db.table\n",
+    "create_db(spark, _TARGET_DB_NAME)\n",
+    "create_repartitioned_table(spark, df, _TARGET_TABLE_NAME, _TARGET_DB_NAME, 10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Create notebook for the bootstrap stage that creates the initial table for `silver.word_states`.

Creates `silver.word_states` table with columns:
- `word`
- `letter_set`
- `frequency`
- `embedding`
- `last_seen_on` (date type, nullable)
- `label` (`0.0` or `1.0`, nullable)
- `batch_id` (string, `"bootstrap_{stage}_{num}"` or `str(puzzle_date)`

Steps in the process:
- reduce the batch reader size to avoid vectorized reader using too much memory
- TODO: Find out if this step should only happen locally or on Databricks too
    - if local only, put this config change in `if not is_databricks_env():` block
- read in `bronze.words` Delta table
- rename `date_added` -> `last_seen_on` (should all be null for bootstrap)
- label column = null (float type)
- batch_id col = `"bootstrap_words_01"`
- drop version column
- save as Delta table `silver.word_states`