### PR TITLE
refactor bootstrap word decisions

### DIFF
--- a/notebooks/00_setup.ipynb
+++ b/notebooks/00_setup.ipynb
@@ -116,7 +116,7 @@
     "        .config(\"spark.sql.parquet.compression.codec\", \"gzip\") \\\n",
     "        .enableHiveSupport() \n",
     "\n",
-    "    print(\"Initializing Spark (this will be verbose for ~30 seconds)...\")\n",
+    "    print(\"Initializing Spark (this will be verbose for several seconds)...\")\n",
     "    spark = configure_spark_with_delta_pip(builder).getOrCreate()\n",
     "    print(\"Spark initialized! Future operations will be much quieter.\")\n",
     "\n",

--- a/notebooks/bootstrap_puzzles_01_insert_word_decisions.ipynb
+++ b/notebooks/bootstrap_puzzles_01_insert_word_decisions.ipynb
@@ -16,17 +16,22 @@
     }
    },
    "source": [
-    "# Backfill: transform_word_decisions\n",
+    "# bootstrap_puzzles_01_insert_word_decisions\n",
     "\n",
-    "Part of historical backfill pipeline\n",
+    "Processes past puzzles in raw storage. For each puzzle, writes a `word_decision` record for each word in the puzzle's answers, as well as each word in the `bronze.words` table which _could_ have been an officila answer (it was possible to form it from the game's letters) but was implicitly rejected.\n",
     "\n",
     "- One backfill pipeline run per year\n",
+    "- Get words from bronze.words, transform into letter_set_map\n",
     "- Work in batches of one month\n",
     "- For each month:\n",
     "    - Get the filepaths of puzzles for that month\n",
-    "    - Transform each puzzle into `word_decisions` table rows\n",
-    "    - write to the bronze table\n",
-    "    - perform validation checks and audit logs before and after each write op\n",
+    "    - Transform each puzzle into `word_decisions` table rows, using the letter_set_map\n",
+    "    - Write batch of rows to the bronze table\n",
+    "    - TODO: perform validation checks and audit logs before and after each write op\n",
+    "\n",
+    "## NOTE:\n",
+    "- Bootstrap for all puzzles up to and including 2025-06-23\n",
+    "- Do not include puzzles beyond this date \n",
     "\n",
     "## ⚠️ Not working locally? ⚠️\n",
     "\n",
@@ -58,7 +63,19 @@
    },
    "outputs": [],
    "source": [
-    "%run \"./00_setup\""
+    "%run \"./00_setup.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.bronzeutils import rows_to_word_decisions_df, WORD_DECISIONS_PARTITIONS\n",
+    "from src.fileutils import get_puzzle_paths\n",
+    "from src.sparkdbutils import create_db, write_to_table_replace_where\n",
+    "from src.wordutils import get_letter_set_map, transform_puzzle_to_word_decisions_by_path"
    ]
   },
   {
@@ -79,8 +96,6 @@
    },
    "outputs": [],
    "source": [
-    "from pyspark.sql.types import * \n",
-    "import pyspark.sql.functions as F\n",
     "from typing import Any"
    ]
   },
@@ -94,7 +109,7 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
-     "nuid": "8b896b40-c5eb-4f38-8398-8fc5f8792c8a",
+     "nuid": "b13f3f61-27f1-4c80-8f3b-1fdf3a81dfbd",
      "showTitle": false,
      "tableResultSettingsMap": {},
      "title": ""
@@ -102,33 +117,24 @@
    },
    "outputs": [],
    "source": [
-    "from src.sparkdbutils import create_db, write_to_table_replace_where\n",
-    "from src.fileutils import get_latest_wordlist, word_file_to_set, get_puzzle_paths\n",
-    "from src.wordutils import get_letter_set_map, transform_puzzle_to_word_decisions_by_path\n",
-    "from src.bronzeutils import rows_to_word_decisions_df, WORD_DECISIONS_PARTITIONS"
+    "# TODO: Parameterize _YEAR, _TARGET_DB_NAME, _TABLE_NAME\n",
+    "_YEAR = 2025\n",
+    "_SOURCE_DB_NAME = \"bronze\"\n",
+    "_SOURCE_TABLE_NAME = \"words\"\n",
+    "_TARGET_DB_NAME = \"bronze\"\n",
+    "_TARGET_TABLE_NAME = \"word_decisions\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "9cedea94-ee3f-4d61-8ba2-25c0924550ea",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "wordlist_filename, wordlist_version = get_latest_wordlist()\n",
-    "wordlist = word_file_to_set(wordlist_filename)\n",
-    "letter_set_map = get_letter_set_map(wordlist)"
+    "# Get all words and convert to letter_set_map\n",
+    "words_df = spark.sql(f\"SELECT word FROM {_SOURCE_DB_NAME}.{_SOURCE_TABLE_NAME}\")\n",
+    "words_list = sorted([row.word for row in words_df.select(\"word\").collect()])\n",
+    "letter_set_map = get_letter_set_map(words_list)"
    ]
   },
   {
@@ -156,10 +162,7 @@
     "    rows = []\n",
     "    puzzle_paths = get_puzzle_paths(year, month)\n",
     "    for puzzle_path in sorted(puzzle_paths):\n",
-    "        curr_rows = transform_puzzle_to_word_decisions_by_path(puzzle_path,\n",
-    "                                                               wordlist,\n",
-    "                                                               letter_set_map,\n",
-    "                                                               wordlist_version)\n",
+    "        curr_rows = transform_puzzle_to_word_decisions_by_path(puzzle_path, letter_set_map)\n",
     "        rows.extend(curr_rows)\n",
     "\n",
     "    return rows_to_word_decisions_df(rows, spark)"
@@ -168,25 +171,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "b13f3f61-27f1-4c80-8f3b-1fdf3a81dfbd",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: Parameterize _YEAR, _TARGET_DB_NAME, _TABLE_NAME\n",
-    "_YEAR = 0000\n",
-    "_TARGET_DB_NAME = \"bronze\"\n",
-    "_TABLE_NAME = \"word_decisions\"\n",
+    "# Create db if not done already\n",
     "create_db(spark, _TARGET_DB_NAME)"
    ]
   },
@@ -216,7 +204,7 @@
     "    \n",
     "    curr_count = df.count()\n",
     "    total_rows += curr_count\n",
-    "    print(f\"Writing {curr_count} rows to {_TARGET_DB_NAME}.{_TABLE_NAME}\")\n",
+    "    print(f\"Writing {curr_count} rows to {_TARGET_DB_NAME}.{_TARGET_TABLE_NAME}\")\n",
     "    replace_where_dict = {\n",
     "        \"year\": _YEAR,\n",
     "        \"month\": month,\n",
@@ -224,79 +212,34 @@
     "    write_to_table_replace_where(spark,\n",
     "                   df,\n",
     "                   _TARGET_DB_NAME,\n",
-    "                   _TABLE_NAME,\n",
+    "                   _TARGET_TABLE_NAME,\n",
     "                   replace_where_dict,\n",
     "                   WORD_DECISIONS_PARTITIONS)\n",
     "\n",
     "    # TODO: validation, audit log, etc.\n",
-    "print(f\"{total_rows} written in total\")"
+    "print(f\"{total_rows} rows written in total\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "a05db5ca-7a60-42f5-bbdb-9f6b28710ae0",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "df2 = spark.sql(\"SELECT * FROM bronze.word_decisions\")\n",
-    "print(f\"{df2.count()} total rows in table\")\n",
-    "df2.show(10, False)"
+    "# Uncomment for debugging / validation\n",
+    "# df2 = spark.sql(\"SELECT * FROM bronze.word_decisions\")\n",
+    "# print(f\"{df2.count()} total rows in table\")\n",
+    "# df2.show(10, False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "b44e81ee-1d4a-4ef8-938c-e99d409a4cfd",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "df2.select([\"year\", \"month\"]).distinct().sort([\"year\", \"month\",]).show(50, False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "3169ec07-5f98-4757-a90f-f9ee6e4ec293",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "new_words = df2.filter(df2.was_in_wordlist == False).select(\"word\").distinct().sort(\"word\")\n",
-    "print(f\"{new_words.count()} words not found in external wordlist\")\n",
-    "new_words.show(new_words.count())"
+    "# Uncomment for debugging / validation\n",
+    "# df2.select([\"year\", \"month\"]).distinct().sort([\"year\", \"month\",]).show(50, False)"
    ]
   }
  ],

--- a/notebooks/bootstrap_words_04_word_states.ipynb
+++ b/notebooks/bootstrap_words_04_word_states.ipynb
@@ -5,7 +5,7 @@
    "id": "d6f22e25-df7c-4aed-9e83-55f9fca341db",
    "metadata": {},
    "source": [
-    "# bootstrap_words_03_word_states\n",
+    "# bootstrap_words_04_word_states\n",
     "\n",
     "Creates `silver.word_states` table with columns:\n",
     "- `word`\n",

--- a/src/bronzeutils.py
+++ b/src/bronzeutils.py
@@ -19,12 +19,10 @@ WORD_DECISIONS_PARTITIONS = ["year", "month"]
 word_decisions_schema: StructType = StructType(
     [
         StructField("word", StringType(), False),
-        StructField("accepted", BooleanType(), False),
-        StructField("was_in_wordlist", BooleanType(), False),
-        StructField("puzzle_date", DateType(), False),
         StructField("center_letter", StringType(), False),
         StructField("outer_letters", StringType(), False),
-        StructField("wordlist_version", IntegerType(), False),
+        StructField("puzzle_date", DateType(), False),
+        StructField("accepted", FloatType(), False)
     ]
 )
 
@@ -40,7 +38,7 @@ words_schema: StructType = StructType([
 
 def rows_to_word_decisions_df(rows: list[Any], spark: SparkSession) -> DataFrame:
     """
-    Writes rows to dataframe and (TODO) saves to table
+    Writes rows to dataframe
     """
     df = spark.createDataFrame(rows, schema=word_decisions_schema)
 

--- a/src/wordutils.py
+++ b/src/wordutils.py
@@ -29,6 +29,7 @@ def get_letter_set(word: str) -> str:
     distinct_letters = set(word)
     return "".join(sorted(distinct_letters)).upper()
 
+
 def filter_wordlist(words: set[str]) -> set[str]:
     """
     Remove words from list that cannot be Spelling Beee solutions.
@@ -47,6 +48,7 @@ def filter_wordlist(words: set[str]) -> set[str]:
         output.add(word)
 
     return output
+
 
 def get_letter_set_map(wordlist: set[str]) -> dict[str, list[Any]]:
     """Takes a wordlist and groups them by the distinct letter sets
@@ -87,9 +89,7 @@ def get_matching_words(
 
 def _transform_puzzle_to_word_decisions(
     puzzle: dict[str, Any],
-    wordlist: set[str],
     letter_set_map: dict[str, list[Any]],
-    wordlist_version: int,
 ) -> list[dict[str, Any]]:
     """
     For the given puzzle, wordlist, and letter_set_map:
@@ -116,12 +116,10 @@ def _transform_puzzle_to_word_decisions(
         rows.append(
             {
                 "word": word,
-                "accepted": word in official_solution,
-                "was_in_wordlist": word in wordlist,
-                "puzzle_date": datetime.strptime(puzzle_date, DATE_FORMAT),
                 "center_letter": center_letter,
                 "outer_letters": outer_letters,
-                "wordlist_version": wordlist_version,
+                "puzzle_date": datetime.strptime(puzzle_date, DATE_FORMAT),
+                "accepted": float(word in official_solution)
             }
         )
 
@@ -130,23 +128,17 @@ def _transform_puzzle_to_word_decisions(
 
 def transform_puzzle_to_word_decisions_by_path(
     puzzle_path: str,
-    wordlist: set[str],
     letter_set_map: dict[str, list[Any]],
-    wordlist_version: int,
 ) -> list[dict[str, Any]]:
 
     puzzle = get_puzzle_by_path(puzzle_path)
 
-    return _transform_puzzle_to_word_decisions(
-        puzzle, wordlist, letter_set_map, wordlist_version
-    )
+    return _transform_puzzle_to_word_decisions(puzzle, letter_set_map)
 
 
 def transform_puzzle_to_word_decisions_by_date(
     puzzle_date: str,
-    wordlist: set[str],
     letter_set_map: dict[str, list[Any]],
-    wordlist_version: int,
 ) -> list[dict[str, Any]]:
     """
     Read in puzzle for the given date, finds all possible words in wordlist that
@@ -155,6 +147,4 @@ def transform_puzzle_to_word_decisions_by_date(
     """
     puzzle = get_puzzle_by_date(puzzle_date)
 
-    return _transform_puzzle_to_word_decisions(
-        puzzle, wordlist, letter_set_map, wordlist_version
-    )
+    return _transform_puzzle_to_word_decisions(puzzle, letter_set_map)


### PR DESCRIPTION
Processes past puzzles in raw storage. For each puzzle, writes a `word_decision` record for each word in the puzzle's answers, as well as each word in the `bronze.words` table which _could_ have been an officila answer (it was possible to form it from the game's letters) but was implicitly rejected.

- One backfill pipeline run per year
- Get words from bronze.words, transform into letter_set_map
- Work in batches of one month
- For each month:
    - Get the filepaths of puzzles for that month
    - Transform each puzzle into `word_decisions` table rows, using the letter_set_map
    - Write batch of rows to the bronze table
    - TODO: perform validation checks and audit logs before and after each write op

**Note**
- Bootstrap for all puzzles up to and including 2025-06-23
- Do not include puzzles beyond this date 