### PR TITLE
Bootstrap puzzles: update word states

### DIFF
--- a/notebooks/bootstrap_puzzles_02_update_word_states.ipynb
+++ b/notebooks/bootstrap_puzzles_02_update_word_states.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "767965ea-59e5-46a0-bdc9-96c71ece9361",
+   "metadata": {},
+   "source": [
+    "# bootstrap_puzzles_02_update_word_states\n",
+    "\n",
+    "Using word data from past puzzles, updates the initial `silver.word_states` table.\n",
+    "\n",
+    "The `silver.word_states` table reflects the latest state of each word we are tracking, specifically:\n",
+    "\n",
+    "- `last_seen_on`: the date of the most recent explicit or implicit decision made about the word (can be null if the word has never been a possible puzzle answer)\n",
+    "- `label`:\n",
+    "    - `1.0` if the most recent decision explicitly included in the word in the official solution\n",
+    "    - `0.0` if the most recent decision implicity rejected the word (it could be formed with the puzzle letters but was not included in the official solution)\n",
+    "    - `null` if the word has never been a possible puzzle answer\n",
+    "- `batch_id`: an identifier of the current puzzle or date range being processed, to support idempotent ops and redos\n",
+    "- the `word`, `letter_set`, `frequency`, `embedding` columns from `bronze.words` for the given word.\n",
+    "\n",
+    "The process of updating the `silver.word_states` table is:\n",
+    "\n",
+    "- Read `bronze.word_decisions` into a data frame and use a window function to select the most recent decision about each word in the table. (For each word, find the decision with the latest `puzzle_date`.)\n",
+    "- Rename `puzzle_date` to `last_seen_on`\n",
+    "- Rename `accepted` to `label`\n",
+    "- Add `batch_id` `\"bootstrap_puzzles_1\"` for this notebook\n",
+    "- Identify new words and query/join their `letter_set`, `embedding`, and `frequency` columns so they can be inserted\n",
+    "- Use Delta `MERGE INTO` semantics to update the latest decisions:\n",
+    "    - merge into on the key match `source.word = target.word`\n",
+    "    - `whenMatchedUpdate` on the condition `target.last_seen_on IS NULL OR source.last_seen_on >= target.last_seen_on`\n",
+    "        - update the `last_seen_on`, `label`, and `batch_id` columns with the value in the source\n",
+    "        - leave the `word`, `letter_set`, `frequency`, and `embedding` columns unchanged in the target (these are static properties of the word, not the decision). \n",
+    "    - `whenNotMatchedInsert` for decisions about words that are not present in the target table (this is not expected in bootstrap)\n",
+    "    - `whenNotMatchedBySourceDelete` to handle the case of reruns that must clean up rows from a previous run that should not have been added. The condition is `source.batch_id = target.batch_id`\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05d62310-f837-42f6-901c-2f187fbcf148",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run \"./00_setup.ipynb\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11a9b0c6-3f7b-4eda-9b6e-f870482d0c77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Config for this notebook, possibly local only\n",
+    "# TODO: Remove this if not needed except for debugging\n",
+    "\n",
+    "from src.envutils import is_databricks_env\n",
+    "\n",
+    "if not is_databricks_env():\n",
+    "    print(\"updating spark config for this notebook\")\n",
+    "    spark.conf.set(\"spark.sql.parquet.columnarReaderBatchSize\", \"1024\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1f15fe2-0d84-4f63-8be8-b87fc81c92f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyspark.sql.functions as F\n",
+    "from pyspark.sql.window import Window\n",
+    "from delta.tables import DeltaTable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8823a11a-527a-4725-9f11-c17041f78f41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: parameterize\n",
+    "_SOURCE_DB_NAME = \"bronze\"\n",
+    "_SOURCE_DECISIONS_TABLE_NAME = \"word_decisions\"\n",
+    "_SOURCE_WORDS_TABLE_NAME = \"words\"\n",
+    "_TARGET_DB_NAME = \"silver\"\n",
+    "_TARGET_TABLE_NAME = \"word_states\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df0fe2bd-4412-4999-8854-fda98e7f068a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the word decisions\n",
+    "df = spark.sql(f\"SELECT * FROM {_SOURCE_DB_NAME}.{_SOURCE_DECISIONS_TABLE_NAME}\")\n",
+    "print(f\"{df.count()} word_decisions in {_SOURCE_DB_NAME}.{_SOURCE_DECISIONS_TABLE_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "010af63a-d092-4849-88a9-101c44fec324",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_distinct = df.select(\"word\").distinct().count()\n",
+    "print(f\"Number of distinct words in {_SOURCE_DB_NAME}.{_SOURCE_DECISIONS_TABLE_NAME}: {num_distinct}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "354a0428-96c8-46e2-bee7-b1a9a51305c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define window partitioned by word, ordered by puzzle_date\n",
+    "window_spec = Window.partitionBy(\"word\").orderBy(F.col(\"puzzle_date\").desc())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94c372d0-ee25-4025-a41e-9a333f41c804",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add row number to identify the most recent record\n",
+    "# Then filter on the first (most recent record)\n",
+    "filtered_df = df.withColumn(\"rn\", F.row_number().over(window_spec)) \\\n",
+    "                .filter(F.col(\"rn\") == 1) \\\n",
+    "                .drop(\"rn\")\n",
+    "\n",
+    "print(f\"Num records after filter: {filtered_df.count()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14fe4e98-c4db-4c11-a504-237d9d1ef866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rename puzzle_date to last_seen_on\n",
+    "# Add batch_id \"bootstrap_puzzles_1\" for this notebook\n",
+    "BATCH_ID = \"bootstrap_puzzles_1\"\n",
+    "source_df = filtered_df.withColumnRenamed(\"puzzle_date\", \"last_seen_on\") \\\n",
+    "                       .withColumnRenamed(\"accepted\", \"label\") \\\n",
+    "                       .withColumn(\"batch_id\", F.lit(BATCH_ID))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d9ed6fe-4291-4b59-b131-ef851336d3ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identify which words in source_df won't be matched in the target table\n",
+    "target_words_df = spark.sql(f\"SELECT word FROM {_TARGET_DB_NAME}.{_TARGET_TABLE_NAME}\")\n",
+    "target_words = set([row.word for row in target_words_df.select(\"word\").collect()])\n",
+    "\n",
+    "source_words = set([row.word for row in source_df.select(\"word\").collect()])\n",
+    "\n",
+    "new_words = source_words - target_words\n",
+    "print(f\"Found {len(target_words)} distinct words in target.\")\n",
+    "print(f\"Found {len(source_words)} distinct words in source.\")\n",
+    "print(f\"Found {len(new_words)} new words in source.\")\n",
+    "if len(new_words) > 0:\n",
+    "    print(f\"New words: {', '.join(sorted(new_words))}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e094977d-3b80-437d-b8a7-0b6bdc1ea11d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if len(new_words) > 0:\n",
+    "    # Get embeddings and frequencies for new words, join to source_df\n",
+    "    formatted_new_words = ', '.join([f\"'{word}'\" for word in sorted(new_words)])\n",
+    "    query = f\"\"\"\n",
+    "        SELECT word, letter_set, embedding, frequency\n",
+    "        FROM {_SOURCE_DB_NAME}.{_SOURCE_WORDS_TABLE_NAME}\n",
+    "        WHERE word IN ({formatted_new_words})\n",
+    "    \"\"\"\n",
+    "    new_words_df = spark.sql(query)\n",
+    "    \n",
+    "    # Join to enrich source_df with extra columns\n",
+    "    source_df = source_df.join(new_words_df, on=\"word\", how=\"left\")\n",
+    "else:\n",
+    "    # No new words. Add NULL columns explicitly\n",
+    "    source_df = source_df.withColumn(\"letter_set\", F.lit(None).cast(\"string\")) \\\n",
+    "                         .withColumn(\"embedding\", F.lit(None).cast(\"array<float>\")) \\\n",
+    "                         .withColumn(\"frequency\", F.lit(None).cast(\"float\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a302e52e-6d6d-42bc-ad97-de2acbc9384b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_table = DeltaTable.forName(spark, f\"{_TARGET_DB_NAME}.{_TARGET_TABLE_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecfc2459-feeb-4e07-ac37-73af87f88429",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use DeltaMergeBuilder for the merge operation\n",
+    "merge_builder = target_table.alias(\"target\").merge(\n",
+    "    source_df.alias(\"source\"),\n",
+    "    \"target.word = source.word\"\n",
+    ")\n",
+    "\n",
+    "# Define the merge logic\n",
+    "merge_builder.whenMatchedUpdate(\n",
+    "    condition=\"target.last_seen_on is null OR source.last_seen_on >= target.last_seen_on\",\n",
+    "    set={\n",
+    "        \"label\": \"source.label\",\n",
+    "        \"last_seen_on\": \"source.last_seen_on\",\n",
+    "        \"batch_id\": \"source.batch_id\"\n",
+    "    }\n",
+    ").whenNotMatchedInsert(\n",
+    "    values={\n",
+    "        \"word\": \"source.word\",\n",
+    "        \"letter_set\": \"source.letter_set\",\n",
+    "        \"frequency\": \"source.frequency\",\n",
+    "        \"embedding\": \"source.embedding\",\n",
+    "        \"last_seen_on\": \"source.last_seen_on\", \n",
+    "        \"label\": \"source.label\",\n",
+    "        \"batch_id\": \"source.batch_id\"\n",
+    "    }\n",
+    ").whenNotMatchedBySourceDelete(\n",
+    "    condition=f\"target.batch_id = '{BATCH_ID}'\"\n",
+    ").execute()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/bootstrap_puzzles_02_update_word_states.ipynb
+++ b/notebooks/bootstrap_puzzles_02_update_word_states.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# bootstrap_puzzles_02_update_word_states\n",
     "\n",
-    "Using word data from past puzzles, updates the initial `silver.word_states` table.\n",
+    "Using word data from past puzzles, updates the initial `silver.word_states` table based on the `bronze.word_decisions` records created after ingesting all of the past puzzles up to (including) 2025-06-23.\n",
+    "\n",
+    "This notebook performs the update all in one shot, rather than month by month. If this causes memory-related performance issues, we can refactor to run month by month. Another TODO will be to have the pipeline for the previous stage (which goes year/month by year/month) loop through all of the past years (2023, 2024, 2025) and run the notebook for each one, before proceeding to this stage.\n",
     "\n",
     "The `silver.word_states` table reflects the latest state of each word we are tracking, specifically:\n",
     "\n",


### PR DESCRIPTION
# bootstrap_puzzles_02_update_word_states

Using word data from past puzzles, updates the initial `silver.word_states` table based on the `bronze.word_decisions` records created after ingesting all of the past puzzles up to (including) 2025-06-23.

This notebook performs the update all in one shot, rather than month by month. If this causes memory-related performance issues, we can refactor to run month by month. Another TODO will be to have the pipeline for the previous stage (which goes year/month by year/month) loop through all of the past years (2023, 2024, 2025) and run the notebook for each one, before proceeding to this stage.

The `silver.word_states` table reflects the latest state of each word we are tracking, specifically:

- `last_seen_on`: the date of the most recent explicit or implicit decision made about the word (can be null if the word has never been a possible puzzle answer)
- `label`:
    - `1.0` if the most recent decision explicitly included in the word in the official solution
    - `0.0` if the most recent decision implicity rejected the word (it could be formed with the puzzle letters but was not included in the official solution)
    - `null` if the word has never been a possible puzzle answer
- `batch_id`: an identifier of the current puzzle or date range being processed, to support idempotent ops and redos
- the `word`, `letter_set`, `frequency`, `embedding` columns from `bronze.words` for the given word.

The process of updating the `silver.word_states` table is:

- Read `bronze.word_decisions` into a data frame and use a window function to select the most recent decision about each word in the table. (For each word, find the decision with the latest `puzzle_date`.)
- Rename `puzzle_date` to `last_seen_on`
- Rename `accepted` to `label`
- Add `batch_id` `"bootstrap_puzzles_1"` for this notebook
- Identify new words and query/join their `letter_set`, `embedding`, and `frequency` columns so they can be inserted
- Use Delta `MERGE INTO` semantics to update the latest decisions:
    - merge into on the key match `source.word = target.word`
    - `whenMatchedUpdate` on the condition `target.last_seen_on IS NULL OR source.last_seen_on >= target.last_seen_on`
        - update the `last_seen_on`, `label`, and `batch_id` columns with the value in the source
        - leave the `word`, `letter_set`, `frequency`, and `embedding` columns unchanged in the target (these are static properties of the word, not the decision). 
    - `whenNotMatchedInsert` for decisions about words that are not present in the target table (this is not expected in bootstrap)
    - `whenNotMatchedBySourceDelete` to handle the case of reruns that must clean up rows from a previous run that should not have been added. The condition is `source.batch_id = target.batch_id`

