### PR TITLE
Updates when running training in Databricks

### DIFF
--- a/notebooks/00_setup.ipynb
+++ b/notebooks/00_setup.ipynb
@@ -4,10 +4,7 @@
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
+     "cellMetadata": {},
      "inputWidgets": {},
      "nuid": "e2b6ee7a-6b3f-4031-9e93-fc0f5769b48e",
      "showTitle": false,
@@ -22,12 +19,13 @@
     "    - `from src import <module>`\n",
     "    - `from src.mymodule import myfunc`\n",
     "- Starts up spark session in local environment only (not needed in Databricks)\n",
+    "- Sets random seed for all operations in the driver\n",
     "      "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -45,12 +43,34 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "from pathlib import Path"
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import random"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "5b064288-3cbd-48da-ac1e-4279a6f90a63",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "random.seed(0)\n",
+    "np.random.seed(0)\n",
+    "print(\"🎲 Set random.seed(0) and np.random.seed(0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -77,8 +97,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "c353afc1-b47c-4d25-9e21-29c6c0f4b066",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
    "outputs": [],
    "source": [
     "def create_spark_session():\n",
@@ -127,8 +156,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "815b8313-19e5-46ff-9b12-89eeca3f0826",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
    "outputs": [],
    "source": [
     "# Start spark session for local environment only\n",
@@ -141,8 +179,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "246e4ceb-27a4-41be-bfc4-62eb30f0edac",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
    "outputs": [],
    "source": [
     "# Config for this notebook, possibly local only\n",
@@ -174,18 +221,9 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "name": "python"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/notebooks/bootstrap_puzzles_01_insert_word_decisions.ipynb
+++ b/notebooks/bootstrap_puzzles_01_insert_word_decisions.ipynb
@@ -68,7 +68,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "024b0ad0-eb99-4325-9d0c-a4febcb6fc44",
      "showTitle": false,
@@ -124,7 +127,7 @@
    "outputs": [],
    "source": [
     "# TODO: Parameterize _YEAR, _TARGET_DB_NAME, _TABLE_NAME\n",
-    "_YEAR = 2025\n",
+    "_YEAR = 2023\n",
     "_SOURCE_DB_NAME = \"bronze\"\n",
     "_SOURCE_TABLE_NAME = \"words\"\n",
     "_TARGET_DB_NAME = \"bronze\"\n",
@@ -136,7 +139,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "3ceefd51-db4b-4869-a6f5-cfd301f3534f",
      "showTitle": false,
@@ -170,7 +176,7 @@
    },
    "outputs": [],
    "source": [
-    "def process_month(year: int, month: int) -> list[dict[str, Any]]:\n",
+    "def process_month(year: int, month: int, letter_set_map: dict[str, list[Any]]) -> list[dict[str, Any]]:\n",
     "    \"\"\"\n",
     "    Returns word_decision rows for all puzzles in the given year/month\n",
     "    \"\"\"\n",
@@ -188,7 +194,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "624b43de-8f52-4828-a965-ad814f7938b7",
      "showTitle": false,
@@ -224,7 +233,7 @@
     "\n",
     "for month in range(1, 13):\n",
     "    print(f\"Processing year {_YEAR}, month {month}...\")\n",
-    "    df = process_month(_YEAR, month)\n",
+    "    df = process_month(_YEAR, month, letter_set_map)\n",
     "    \n",
     "    curr_count = df.count()\n",
     "    total_rows += curr_count\n",
@@ -249,7 +258,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ea233b82-57a8-48d5-9fdd-1ad3a975f2ac",
      "showTitle": false,
@@ -270,7 +282,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "52195f35-f1bc-4921-83ae-0f680e6bbbde",
      "showTitle": false,

--- a/notebooks/bootstrap_puzzles_03_word_probabilities.ipynb
+++ b/notebooks/bootstrap_puzzles_03_word_probabilities.ipynb
@@ -43,7 +43,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d2a8e215-25c8-4203-9fba-3d37b7f1b758",
      "showTitle": false,
@@ -62,7 +65,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1717401f-75bc-4a24-a6e8-e7d411926b14",
      "showTitle": false,
@@ -89,7 +95,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "2d9d2211-7880-48a4-929e-26f01dfbd6a6",
      "showTitle": false,
@@ -111,7 +120,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8e6b83ac-0299-4188-afa7-22d9cc7d1302",
      "showTitle": false,
@@ -130,7 +142,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "287ea0d3-e036-46f3-af97-1d7ca0a927e6",
      "showTitle": false,
@@ -149,7 +164,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a51021ff-7bce-4230-8ed9-aa16e9e6854a",
      "showTitle": false,
@@ -175,7 +193,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f74ff607-1092-48f2-a876-d0a3aec97d43",
      "showTitle": false,
@@ -196,7 +217,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8f1c6cfd-d664-42b2-be9a-6c4d7468a3c0",
      "showTitle": false,
@@ -224,7 +248,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "72f343ee-9097-4c3d-8714-db2a818ce347",
      "showTitle": false,
@@ -236,6 +263,8 @@
    "source": [
     "def setup_worker_imports():\n",
     "    import sys\n",
+    "    import random\n",
+    "    \n",
     "    from pathlib import Path\n",
     "    current_dir = Path(os.getcwd())\n",
     "    project_root = current_dir.parent\n",
@@ -256,6 +285,8 @@
     "    # UDF functions run in separate processes with their own namespaces\n",
     "    # so it is necessary to import the classes of the SVD and classifier\n",
     "    # as though we are running a new file in a brand new process.\n",
+    "    random.seed(0)\n",
+    "    np.random.seed(0)\n",
     "    setup_worker_imports()\n",
     "    \n",
     "    from src.models.HybridFrequencyBinaryClassifier import HybridFrequencyBinaryClassifier\n",
@@ -288,7 +319,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "bdea78c0-5589-4104-8876-ff83343f714d",
      "showTitle": false,
@@ -309,7 +343,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "92842918-5492-41ff-9de7-bb7f318af745",
      "showTitle": false,
@@ -329,7 +366,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "6cd816ed-2ca3-4f94-8093-0b891874b44d",
      "showTitle": false,
@@ -348,7 +388,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8c80d9f9-0605-43cb-a35a-dd3ae48488a4",
      "showTitle": false,
@@ -368,7 +411,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "bf6e9b9d-03f1-45b8-ae1b-b611bcf119fb",
      "showTitle": false,
@@ -387,7 +433,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c49dc5e5-9e71-49ed-b9b0-f7ea5a19361a",
      "showTitle": false,
@@ -411,7 +460,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "c52e89e2-e53d-44d2-b8d9-c44941ff7daa",
      "showTitle": false,

--- a/notebooks/bootstrap_words_04_word_states.ipynb
+++ b/notebooks/bootstrap_words_04_word_states.ipynb
@@ -41,7 +41,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "5b7f9f27-6fc0-4cd8-9c7b-d4def3a5c9bc",
      "showTitle": false,
@@ -51,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "%run './00_setup'"
+    "%run \"./00_setup\""
    ]
   },
   {
@@ -59,7 +62,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f76a63cb-c285-4901-91e2-6d85399e5c78",
      "showTitle": false,
@@ -81,7 +87,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "61becbf7-0ba0-4a61-a58b-f74f4754c163",
      "showTitle": false,
@@ -103,7 +112,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ea12e00e-34a8-43d4-8a1f-ef07d707c9bf",
      "showTitle": false,
@@ -122,7 +134,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "80974071-54c7-48fe-97d5-738b40790694",
      "showTitle": false,
@@ -141,7 +156,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1adc2544-12b0-4603-a999-c905aeaabda5",
      "showTitle": false,
@@ -160,7 +178,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1be370c6-003e-4c14-94bb-9dca352f764b",
      "showTitle": false,
@@ -179,7 +200,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "938fed9d-5c0a-4fc2-afc4-3e682062706d",
      "showTitle": false,
@@ -198,7 +222,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "e89e344d-410e-4691-baf5-66857c7a1ea7",
      "showTitle": false,
@@ -212,6 +239,22 @@
     "create_db(spark, _TARGET_DB_NAME)\n",
     "create_repartitioned_table(spark, df, _TARGET_TABLE_NAME, _TARGET_DB_NAME, 10)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "9101bd2a-7424-4130-bf00-9673fa7e57d4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/train_v1.ipynb
+++ b/notebooks/train_v1.ipynb
@@ -23,7 +23,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "7a495f0c-2e16-45e2-885b-bc41ce23a564",
      "showTitle": false,
@@ -33,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "%run './00_setup'"
+    "%run \"./00_setup\""
    ]
   },
   {
@@ -41,7 +44,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "21d974a3-c59f-4617-985a-1bc63439e238",
      "showTitle": false,
@@ -62,7 +68,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1b97f3b4-d0f0-484a-8768-075ec3492206",
      "showTitle": false,
@@ -91,7 +100,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8f453a6c-a139-42f4-991d-c1f0eea4c7e1",
      "showTitle": false,
@@ -115,7 +127,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "7b08ab84-d353-4bfb-9610-d24bce31fb13",
      "showTitle": false,
@@ -150,7 +165,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "1fe99424-ccf0-4022-8eb3-b66e172cb8c1",
      "showTitle": false,
@@ -186,7 +204,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "262f710e-bfc1-49a5-a6bb-9964dbd8e890",
      "showTitle": false,
@@ -202,12 +223,18 @@
     "\n",
     "    # Initialize model and train\n",
     "    low_freq_clf = GaussianNB()\n",
-    "    mid_freq_clf = LogisticRegression(class_weight=\"balanced\", max_iter=1000, C=C)\n",
+    "    mid_freq_clf = LogisticRegression(class_weight=\"balanced\",\n",
+    "        max_iter=1000,\n",
+    "        C=C,\n",
+    "        random_state=0\n",
+    "    )\n",
+    "    \n",
     "    high_freq_clf = RandomForestClassifier(\n",
     "        n_estimators=100,\n",
     "        max_depth=15,\n",
     "        class_weight='balanced',\n",
-    "        random_state=0\n",
+    "        random_state=0,\n",
+    "        n_jobs=1\n",
     "    )\n",
     "              \n",
     "    clf = HybridFrequencyBinaryClassifier(\n",
@@ -228,7 +255,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ff042d45-e8bf-49ef-9dfa-a005db6658ea",
      "showTitle": false,
@@ -246,7 +276,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ec11bcbc-31e5-43f8-b0c8-17b80bf2a978",
      "showTitle": false,
@@ -264,7 +297,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "a6b37a44-ab4e-4a1c-b53f-bfe98f94938c",
      "showTitle": false,
@@ -286,7 +322,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "5eb4616f-c7b8-4906-843f-05d5e2c825f5",
      "showTitle": false,
@@ -312,7 +351,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "34e6e625-efd4-4b5a-babe-2581c1e380c4",
      "showTitle": false,
@@ -340,7 +382,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "0f222f12-48af-4b56-93d9-0ed7d369a218",
      "showTitle": false,
@@ -359,7 +404,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "f8567e85-dd74-4a8c-b3b8-84c4fc8bd1fc",
      "showTitle": false,
@@ -386,7 +434,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "d3edef5e-6e0c-4ef0-a8ae-65dfed075491",
      "showTitle": false,
@@ -418,7 +469,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "84554fa7-9b1f-4741-a1d9-c9f041efbd5a",
      "showTitle": false,


### PR DESCRIPTION
Re-run training so that pickled model uses the same sklearn version as Databricks (1.3.0 in databricks vs 1.6.1 locally). Add some more hard coded random states to make inference more predictable.